### PR TITLE
feat: move search form into sidebar with two-row layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,79 +28,57 @@
                 <h1>Communauto Flex WebNotify</h1>
                 <p class="subtitle">Find your next ride instantly</p>
             </header>
+        </div>
 
-            <main>
-                <div id="floating-search-bar" class="floating-search-bar hidden">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <circle cx="11" cy="11" r="8"></circle>
-                        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-                    </svg>
-                    <span id="floating-search-text">Montreal - 600m</span>
-                    <svg class="icon-filter" width="20" height="20" viewBox="0 0 24 24" fill="none"
-                        stroke="currentColor" stroke-width="2">
-                        <line x1="4" y1="21" x2="4" y2="14"></line>
-                        <line x1="4" y1="10" x2="4" y2="3"></line>
-                        <line x1="12" y1="21" x2="12" y2="12"></line>
-                        <line x1="12" y1="8" x2="12" y2="3"></line>
-                        <line x1="20" y1="21" x2="20" y2="16"></line>
-                        <line x1="20" y1="12" x2="20" y2="3"></line>
-                        <line x1="1" y1="14" x2="7" y2="14"></line>
-                        <line x1="9" y1="8" x2="15" y2="8"></line>
-                        <line x1="17" y1="16" x2="23" y2="16"></line>
-                    </svg>
-                    <span id="bg-alert-indicator" class="bg-alert-indicator hidden" title="Background alert active">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
-                            <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+        <main class="map-container" id="map-wrapper">
+            <div id="results-overlay" class="results-overlay">
+                <form id="notify-form">
+                    <button type="button" id="btn-filter" class="filter-btn" title="Adjust search radius">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <line x1="4" y1="21" x2="4" y2="14"></line>
+                            <line x1="4" y1="10" x2="4" y2="3"></line>
+                            <line x1="12" y1="21" x2="12" y2="12"></line>
+                            <line x1="12" y1="8" x2="12" y2="3"></line>
+                            <line x1="20" y1="21" x2="20" y2="16"></line>
+                            <line x1="20" y1="12" x2="20" y2="3"></line>
+                            <line x1="1" y1="14" x2="7" y2="14"></line>
+                            <line x1="9" y1="8" x2="15" y2="8"></line>
+                            <line x1="17" y1="16" x2="23" y2="16"></line>
                         </svg>
-                    </span>
-                </div>
+                    </button>
 
-                <form id="notify-form" class="horizontal-form">
-                    <div id="form-inputs" class="form-inputs-row">
-                        <div id="city-indicator" class="form-group city-indicator hidden">
-                            <span id="city-badge" class="city-badge"></span>
-                        </div>
-
-                        <div class="form-group distance-group">
-                            <div class="distance-label-row">
-                                <label for="distance">Radius</label>
-                                <span id="distance-value">600m</span>
-                            </div>
-                            <input type="range" id="distance" name="distance" value="600" min="500" max="2000"
-                                step="100">
-                        </div>
-
-                        <div class="form-group hidden">
-                            <label for="delay" class="sr-only">Interval(s)</label>
-                            <input type="number" id="delay" name="delay" value="30" min="30" max="300"
-                                placeholder="15s">
-                        </div>
-
-                        <div class="form-group location-group">
-                            <div class="location-widget">
-                                <div id="address-input-wrapper" class="address-input-wrapper">
-                                    <input type="text" id="address-input" autocomplete="off"
-                                        placeholder="Enter an address…" spellcheck="false" />
-                                    <ul id="address-suggestions" class="address-suggestions hidden"></ul>
-                                </div>
-                                <button type="button" id="btn-geolocation" class="geo-btn" title="Use Current Location">
-                                    <svg id="geo-icon" width="18" height="18" viewBox="0 0 24 24" fill="none"
-                                        stroke="currentColor" stroke-width="2" stroke-linecap="round">
-                                        <circle cx="12" cy="12" r="8"></circle>
-                                        <line x1="12" y1="2" x2="12" y2="6"></line>
-                                        <line x1="12" y1="18" x2="12" y2="22"></line>
-                                        <line x1="2" y1="12" x2="6" y2="12"></line>
-                                        <line x1="18" y1="12" x2="22" y2="12"></line>
-                                        <circle cx="12" cy="12" r="2" fill="currentColor"></circle>
-                                    </svg>
-                                </button>
-                            </div>
-                            <!-- Hidden field stores the resolved coordinates for form submission -->
-                            <input type="hidden" id="location" name="location" value="">
-                        </div>
+                    <div id="city-indicator" class="city-indicator hidden">
+                        <span id="city-badge" class="city-badge"></span>
                     </div>
+
+                    <!-- Collapsed summary pill: shown when form-inputs is hidden (mobile search) -->
+                    <div id="floating-search-bar" class="floating-search-bar hidden">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="11" cy="11" r="8"></circle>
+                            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                        </svg>
+                        <span id="floating-search-text">Montreal - 600m</span>
+                        <svg class="icon-filter" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                            stroke="currentColor" stroke-width="2">
+                            <line x1="4" y1="21" x2="4" y2="14"></line>
+                            <line x1="4" y1="10" x2="4" y2="3"></line>
+                            <line x1="12" y1="21" x2="12" y2="12"></line>
+                            <line x1="12" y1="8" x2="12" y2="3"></line>
+                            <line x1="20" y1="21" x2="20" y2="16"></line>
+                            <line x1="20" y1="12" x2="20" y2="3"></line>
+                            <line x1="1" y1="14" x2="7" y2="14"></line>
+                            <line x1="9" y1="8" x2="15" y2="8"></line>
+                            <line x1="17" y1="16" x2="23" y2="16"></line>
+                        </svg>
+                        <span id="bg-alert-indicator" class="bg-alert-indicator hidden" title="Background alert active">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
+                                <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+                            </svg>
+                        </span>
+                    </div>
+
                     <div class="form-actions">
                         <button type="submit" id="btn-start" class="primary-btn" disabled>
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
@@ -115,12 +93,43 @@
                             </svg>
                         </button>
                     </div>
-                </form>
-            </main>
-        </div>
 
-        <div class="map-container hidden" id="map-wrapper">
-            <div id="results-overlay" class="results-overlay">
+                    <!-- Expandable inputs: collapses when searching starts -->
+                    <div id="form-inputs" class="form-inputs-col">
+                        <!-- Radius filter: toggled by filter button -->
+                        <div id="form-filters" class="form-row-2 hidden">
+                            <div class="form-group distance-group">
+                                <div class="distance-label-row">
+                                    <label for="distance">Radius</label>
+                                    <span id="distance-value">600m</span>
+                                </div>
+                                <input type="range" id="distance" name="distance" value="600" min="500" max="2000"
+                                    step="100">
+                            </div>
+                            <div class="form-group hidden">
+                                <label for="delay" class="sr-only">Interval(s)</label>
+                                <input type="number" id="delay" name="delay" value="30" min="30" max="300"
+                                    placeholder="15s">
+                            </div>
+                        </div>
+
+                        <!-- Address and GPS -->
+                        <div class="form-row-1">
+                            <div class="form-group location-group">
+                                <div class="location-widget">
+                                    <div id="address-input-wrapper" class="address-input-wrapper hidden">
+                                        <input type="text" id="address-input" autocomplete="off"
+                                            placeholder="Enter an address…" spellcheck="false" />
+                                        <ul id="address-suggestions" class="address-suggestions hidden"></ul>
+                                    </div>
+                                </div>
+                                <!-- Hidden field stores the resolved coordinates for form submission -->
+                                <input type="hidden" id="location" name="location" value="">
+                            </div>
+                        </div>
+                    </div>
+                </form>
+
                 <div id="status-container" class="status-container hidden">
                     <div class="loader"></div>
                     <p id="status-text">Initializing...</p>
@@ -131,9 +140,7 @@
                 </div>
             </div>
             <div id="map"></div>
-        </div>
-
-
+        </main>
     </div>
 
     <div id="app-banner" class="app-banner">

--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -2,6 +2,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-grow: 1;
     background: rgba(30, 41, 59, 0.8);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
@@ -114,6 +115,7 @@
 #status-text {
     font-size: 14px;
     color: var(--text-secondary);
+    white-space: pre-line;
 }
 
 .car-card {

--- a/frontend/static/css/forms.css
+++ b/frontend/static/css/forms.css
@@ -1,17 +1,36 @@
-.horizontal-form {
-    flex-grow: 1;
-    display: flex;
-    flex-direction: row;
-    align-items: flex-end;
-    justify-content: flex-end;
-    gap: 12px;
-}
-
-.form-inputs-row {
+#notify-form {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-color);
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    align-items: flex-end;
+    align-items: center;
+    gap: 8px;
+}
+
+.form-inputs-col {
+    display: flex;
+    flex-direction: column;
+    flex-basis: 100%;
+    min-width: 0;
+    gap: 10px;
+    border-top: 1px solid var(--border-color);
+    padding-top: 10px;
+    margin-top: 2px;
+}
+
+.form-row-1 {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+}
+
+.form-row-2 {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
     gap: 12px;
     width: 100%;
 }
@@ -137,8 +156,8 @@ input[type="range"]::-moz-range-thumb:hover {
 .location-widget {
     display: flex;
     flex-direction: row;
-    align-items: flex-start;
-    gap: 8px;
+    align-items: center;
+    gap: 6px;
     position: relative;
 }
 
@@ -247,6 +266,7 @@ input[type="range"]::-moz-range-thumb:hover {
     align-items: center;
     gap: 8px;
     flex-shrink: 0;
+    margin-left: auto;
 }
 
 button[type="submit"],
@@ -295,7 +315,6 @@ button[type="submit"],
     min-width: unset;
     flex-grow: 0;
     flex-shrink: 0;
-    align-self: flex-end;
 }
 
 .city-badge {
@@ -356,4 +375,31 @@ button[type="submit"],
 
 button:active {
     transform: scale(0.98);
+}
+
+.filter-btn {
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--bg-color);
+    color: var(--text-secondary);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: all 0.2s;
+}
+
+.filter-btn:hover {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+}
+
+.filter-btn.active {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+    background: rgba(59, 130, 246, 0.08);
 }

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -1,7 +1,6 @@
 .layout-container {
     display: flex;
     flex-direction: column;
-    gap: 16px;
     width: 100%;
     max-width: 1400px;
     justify-content: flex-start;
@@ -10,41 +9,26 @@
 
 .top-bar-container {
     background: var(--card-bg);
-    border-radius: 16px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    border-bottom: 1px solid var(--border-color);
     width: 100%;
-    padding: 16px 24px;
-    border: 1px solid var(--border-color);
+    padding: 10px 24px;
     flex-shrink: 0;
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
     align-items: center;
-    gap: 24px;
-}
-
-.top-bar-container main {
-    flex-grow: 1;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 12px;
 }
 
 header {
     text-align: left;
     flex-shrink: 0;
-    min-width: 250px;
 }
 
 .map-container {
     flex-grow: 1;
     background: var(--card-bg);
-    border-radius: 16px;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
     border: 1px solid var(--border-color);
+    border-top: none;
     overflow: hidden;
-    min-height: 500px;
     display: flex;
     flex-direction: row;
     /* side-by-side: panel | map */
@@ -52,7 +36,7 @@ header {
 
 #map {
     flex-grow: 1;
-    min-height: 500px;
+    min-height: 0;
     height: 100%;
     z-index: 1;
 }

--- a/frontend/static/css/responsive.css
+++ b/frontend/static/css/responsive.css
@@ -10,47 +10,32 @@
         display: none !important;
     }
 
-    .form-inputs-row.hidden {
+    #form-inputs.hidden {
         display: flex !important;
     }
 }
 
 /* Tablet & Smaller Desktop (Max Width: 900px) */
 @media (max-width: 900px) {
-    .layout-container {
-        flex-direction: column;
-        height: auto;
-        min-height: 100vh;
-    }
-
-    .top-bar-container {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 16px;
-        padding: 16px;
-    }
-
     header {
         text-align: center;
-        min-width: auto;
     }
 
-    .form-inputs-row {
+    .form-row-1 {
         flex-wrap: wrap;
     }
 
-    /* On small screens, collapse the sidebar into a stacked layout above the map */
+    /* On tablet, stack the sidebar above the map */
     .results-overlay {
         width: 100%;
         height: auto;
-        max-height: 300px;
+        max-height: 40vh;
         border-right: none;
         border-bottom: 1px solid var(--border-color);
     }
 
     .map-container {
         flex-direction: column;
-        min-height: 500px;
         overflow-y: auto;
     }
 }
@@ -59,7 +44,6 @@
 @media (max-width: 480px) {
     .layout-container {
         padding: 0;
-        gap: 0;
         height: 100vh;
     }
 
@@ -67,29 +51,36 @@
         border-radius: 0;
         border: none;
         border-bottom: 1px solid var(--border-color);
-        padding: 10px;
-        gap: 8px;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-        z-index: 10;
-        background: rgba(30, 41, 59, 0.95);
-        backdrop-filter: blur(10px);
+        padding: 8px 16px;
     }
 
-    .horizontal-form {
-        flex-wrap: wrap;
+    .map-container {
+        border-radius: 0;
+        border: none;
+        flex-direction: column;
+        flex-grow: 1;
+        min-height: 0;
     }
 
-    /* ── Two-column layout: City + Distance side-by-side ── */
-    .form-inputs-row {
+    /* ── Sidebar becomes a compact top panel ── */
+    .results-overlay {
+        width: 100%;
+        max-height: 45vh;
+        height: auto;
+        overflow-y: auto;
+        border-right: none;
+        border-bottom: 1px solid var(--border-color);
+        border-radius: 0;
+        flex-shrink: 0;
+    }
+
+    /* ── Compact row 1 ── */
+    .form-row-1 {
         gap: 6px;
     }
 
     .form-group {
         min-width: 0;
-    }
-
-    .form-group:first-child {
-        flex: 0 0 35%;
     }
 
     .distance-group {
@@ -112,44 +103,16 @@
 
     /* ── Compact form actions ── */
     .form-actions {
-        width: 100%;
+        width: auto;
         min-width: 0;
         margin-top: 0;
         flex-direction: row;
     }
 
-    .form-actions button {
-        width: 100%;
-        padding: 10px;
-    }
-
     /* ── Map fills remaining space ── */
-    .map-container {
-        border-radius: 0;
-        border: none;
-        min-height: calc(100vh - 200px);
-        position: relative;
-    }
-
-    /* ── Bottom-sheet results overlay ── */
-    .results-overlay {
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        width: 100%;
-        max-height: 35vh;
-        height: auto;
-        overflow-y: auto;
-        border-right: none;
-        border-bottom: none;
-        border-top: 1px solid var(--border-color);
-        border-radius: 16px 16px 0 0;
-        background: rgba(30, 41, 59, 0.92);
-        backdrop-filter: blur(12px);
-        -webkit-backdrop-filter: blur(12px);
-        box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.3);
-        z-index: 20;
+    #map {
+        flex-grow: 1;
+        min-height: 200px;
     }
 
     .results-container {

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -39,24 +39,6 @@ UIController.els.distance.addEventListener('input', (e) => {
     }
 });
 
-UIController.els.btnGeo.addEventListener('click', async () => {
-    if (UIController.els.btnGeo.disabled) return;
-    UIController.els.btnGeo.disabled = true;
-    LocationController.setLoading();
-    try {
-        const position = await new Promise((resolve, reject) => {
-            navigator.geolocation.getCurrentPosition(resolve, reject, { timeout: 8000 });
-        });
-        LocationController.onGpsSuccess(position);
-        // If location was found via button click, auto-start search
-        AppState.userLocation = [parseFloat(position.coords.latitude.toFixed(6)), parseFloat(position.coords.longitude.toFixed(6))];
-        UIController.els.btnStart.click();
-    } catch {
-        LocationController.onGpsError();
-    } finally {
-        UIController.els.btnGeo.disabled = false;
-    }
-});
 
 UIController.els.form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -152,6 +134,13 @@ UIController.els.floatingSearchBar.addEventListener('click', () => {
     UIController.expandForm();
 });
 
+document.getElementById('btn-filter').addEventListener('click', () => {
+    const filters = document.getElementById('form-filters');
+    const btn = document.getElementById('btn-filter');
+    filters.classList.toggle('hidden');
+    btn.classList.toggle('active');
+});
+
 function stopSearch(message) {
     AppState.isSearching = false;
     clearTimeout(AppState.searchTimeout);
@@ -203,7 +192,7 @@ const AppController = {
 
             MapController.drawCars(mapCars, city);
 
-            UIController.updateStatus(`${cars.length} cars found. ${alertCars.length} within ${MathUtils.humanDistance(AppState.currentDistanceRadius)} (${mapCars.length} map total). Waiting...`);
+            UIController.updateStatus(`${cars.length} cars found.\n${alertCars.length} within ${MathUtils.humanDistance(AppState.currentDistanceRadius)} (${mapCars.length} map total). Waiting...`);
 
             if (alertCars.length > 0) {
                 const topCars = alertCars.slice(0, 3); // Take up to 3 cars

--- a/frontend/static/js/location.js
+++ b/frontend/static/js/location.js
@@ -37,15 +37,10 @@ const LocationController = {
     },
 
     setIdle: function () {
-        const btn = UIController.els.btnGeo;
-        btn.className = 'geo-btn';
+        this.showAddressInput();
     },
 
-    setLoading: function () {
-        const btn = UIController.els.btnGeo;
-        btn.className = 'geo-btn';
-
-    },
+    setLoading: function () {},
 
     // Detects city from coordinates, updates AppState and city badge UI.
     // Returns the detected city string or null.
@@ -71,7 +66,6 @@ const LocationController = {
         if (typeof AppState !== 'undefined') {
             AppState.userLocation = [parseFloat(lat), parseFloat(lng)];
         }
-        UIController.els.btnGeo.className = 'geo-btn geo-success';
 
         const city = this._applyDetectedCity(parseFloat(lat), parseFloat(lng));
 
@@ -83,8 +77,6 @@ const LocationController = {
 
     onGpsError: function () {
         UIController.els.locationInput.value = '';
-        UIController.els.btnGeo.className = 'geo-btn geo-error';
-
         this.showAddressInput();
     },
 
@@ -104,8 +96,6 @@ const LocationController = {
         clearTimeout(this._debounceTimer);
         const query = UIController.els.addressInput.value.trim();
         if (query.length === 0) {
-            // Field cleared — revert to error state so user knows no location is set
-            UIController.els.btnGeo.className = 'geo-btn geo-error';
             UIController.els.btnStart.disabled = true;
             UIController.els.locationInput.value = '';
             if (typeof AppState !== 'undefined') {
@@ -243,9 +233,7 @@ const LocationController = {
             AppState.userLocation = [parseFloat(lat), parseFloat(lng)];
         }
 
-        const city = this._applyDetectedCity(parseFloat(lat), parseFloat(lng));
-        UIController.els.btnGeo.className = city ? 'geo-btn geo-success' : 'geo-btn geo-error';
-
+        this._applyDetectedCity(parseFloat(lat), parseFloat(lng));
         this.hideSuggestions();
     },
 

--- a/frontend/static/js/ui.js
+++ b/frontend/static/js/ui.js
@@ -6,8 +6,6 @@ const UIController = {
         form: document.getElementById('notify-form'),
         btnStart: document.getElementById('btn-start'),
         btnStop: document.getElementById('btn-stop'),
-        btnGeo: document.getElementById('btn-geolocation'),
-
         locationInput: document.getElementById('location'),
         addressWrapper: document.getElementById('address-input-wrapper'),
         addressInput: document.getElementById('address-input'),
@@ -36,12 +34,10 @@ const UIController = {
         this.els.floatingSearchBar.classList.remove('hidden');
 
         this.els.resultsContainer.innerHTML = '';
-        this.els.mapWrapper.classList.remove('hidden');
 
         this.els.distance.disabled = true;
         this.els.delay.disabled = true;
         this.els.locationInput.disabled = true;
-        this.els.btnGeo.disabled = true;
     },
 
     toggleStopped: function () {
@@ -52,7 +48,6 @@ const UIController = {
         this.els.distance.disabled = false;
         this.els.delay.disabled = false;
         this.els.locationInput.disabled = false;
-        this.els.btnGeo.disabled = false;
     },
 
     updateStatus: function (text) {


### PR DESCRIPTION
## Summary

- Move search form from top bar into the results-overlay left sidebar
- Compact action row: `[Filter] [city badge] [pill] [Search/Stop]`, all right-aligned
- Expandable second row: radius slider (toggled by filter btn) + address input below it
- Remove GPS geolocation button — GPS resolves silently on load
- Address input hidden by default; shown only when GPS fails or is at prompt
- GPS success auto-hides address input; city badge in action row shows detected city

## Test plan

- [ ] Desktop: form always expanded in sidebar, address input shows when GPS fails
- [ ] Mobile: form collapses to pill + stop button when searching starts
- [ ] GPS granted: address input stays hidden, city badge appears, search auto-starts
- [ ] GPS denied/prompt: address input appears for manual entry
- [ ] Filter button toggles radius slider above address input
- [ ] All 35 Playwright tests pass