### PR TITLE
fix(ui): prevent mobile header from cutting off install button

### DIFF
--- a/backend/handlers.mjs
+++ b/backend/handlers.mjs
@@ -63,10 +63,12 @@ export function handleGeocodeAddress(requestUrl, res) {
 
     console.log(`[Geocode] Address lookup: ${q}`);
 
-    https.get({ hostname: 'nominatim.openstreetmap.org', path: `/search?${target.searchParams}`, headers: {
-        'Accept-Language': 'fr,en',
-        'User-Agent': 'CommunautoFlexWebNotifier/1.0 (https://github.com/jeromelefeuvre/communauto-flex-webnotifier)'
-    }}, (proxyRes) => {
+    https.get({
+        hostname: 'nominatim.openstreetmap.org', path: `/search?${target.searchParams}`, headers: {
+            'Accept-Language': 'fr,en',
+            'User-Agent': 'CommunautoFlexWebNotifier/1.0 (https://github.com/jeromelefeuvre/communauto-flex-webnotifier)'
+        }
+    }, (proxyRes) => {
         res.writeHead(proxyRes.statusCode, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
         proxyRes.pipe(res);
     }).on('error', (err) => {
@@ -86,9 +88,11 @@ export function handleGeocodePostal(requestUrl, res) {
 
     console.log(`[Geocode] Postal code lookup: ${q}`);
 
-    https.get({ hostname: 'geocoder.ca', path: `/?locate=${encodeURIComponent(q)}&geoit=XML&json=1`, headers: {
-        'User-Agent': 'CommunautoFlexWebNotifier/1.0'
-    }}, (proxyRes) => {
+    https.get({
+        hostname: 'geocoder.ca', path: `/?locate=${encodeURIComponent(q)}&geoit=XML&json=1`, headers: {
+            'User-Agent': 'CommunautoFlexWebNotifier/1.0'
+        }
+    }, (proxyRes) => {
         res.writeHead(proxyRes.statusCode, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
         proxyRes.pipe(res);
     }).on('error', (err) => {
@@ -165,7 +169,7 @@ export function handleStaticFiles(requestUrl, res) {
                     } catch (e) { }
 
                     // Dynamically cache-bust main static assets based on package version
-                    text = text.replace(/href="static\/css\/style\.css"/g, `href="static/css/style.css?v=${version}"`);
+                    text = text.replace(/href="static\/css\/([^"]+)\.css"/g, `href="static/css/$1.css?v=${version}"`);
                     text = text.replace(/src="static\/js\/config\.js"/g, `src="static/js/config.js?v=${version}"`);
                     text = text.replace(/src="static\/js\/utils\.js"/g, `src="static/js/utils.js?v=${version}"`);
                     text = text.replace(/src="static\/js\/ui\.js"/g, `src="static/js/ui.js?v=${version}"`);

--- a/frontend/static/css/responsive.css
+++ b/frontend/static/css/responsive.css
@@ -43,6 +43,32 @@
         padding: 8px 16px;
     }
 
+    header {
+        text-align: left;
+        min-width: 0; /* Allows text truncation in flex container */
+        flex-shrink: 1; /* Allows header to shrink */
+        margin-right: 12px;
+    }
+
+    header h1 {
+        font-size: 18px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .subtitle {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .btn-install-header {
+        flex-shrink: 0; /* Ensure the button never shrinks and gets cut off */
+        padding: 6px 12px;
+        font-size: 12px;
+    }
+
     .map-container {
         border-radius: 0;
         border: none;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "communauto-flex-webnotifier",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "communauto-flex-webnotifier",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "communauto-flex-webnotifier",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Look for close-by Communauto flex cars and get an alert ========================================================",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Fixes the header title overflowing and cutting off the install button on mobile devices. Also fixes a cache busting bug in `handlers.mjs` where only `style.css` was targeted instead of all css files.