### PR TITLE
fix(ui): use CSS grid for mobile header

### DIFF
--- a/frontend/static/css/responsive.css
+++ b/frontend/static/css/responsive.css
@@ -37,36 +37,44 @@
     }
 
     .top-bar-container {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        column-gap: 8px;
+        row-gap: 2px;
         border-radius: 0;
         border: none;
         border-bottom: 1px solid var(--border-color);
-        padding: 8px 16px;
+        padding: 10px 16px;
     }
 
     header {
-        text-align: left;
-        min-width: 0; /* Allows text truncation in flex container */
-        flex-shrink: 1; /* Allows header to shrink */
-        margin-right: 12px;
+        display: contents;
     }
 
     header h1 {
+        grid-column: 1 / -1;
         font-size: 18px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        margin-bottom: 0;
     }
 
     .subtitle {
+        grid-column: 1;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        align-self: center;
+        margin-bottom: 0;
     }
 
     .btn-install-header {
-        flex-shrink: 0; /* Ensure the button never shrinks and gets cut off */
-        padding: 6px 12px;
+        grid-column: 2;
+        justify-self: end;
+        padding: 4px 10px;
         font-size: 12px;
+        margin: 0;
     }
 
     .map-container {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "communauto-flex-webnotifier",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "communauto-flex-webnotifier",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "communauto-flex-webnotifier",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Look for close-by Communauto flex cars and get an alert ========================================================",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Moves the install button to the second row on mobile devices so it sits next to the subtitle, preventing the main title from being cut off.